### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ And now the BMB-Android 2.0.0 comes.
 
 ## Gradle & Maven
 ```
-compile 'com.nightonke:boommenu:2.1.1'
+implementation 'com.nightonke:boommenu:2.1.1'
 ```
 ```
 <dependency>


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.